### PR TITLE
Fix: Content is empty when Content-Encoding-Type is quoted-printable

### DIFF
--- a/parsemail.go
+++ b/parsemail.go
@@ -381,15 +381,13 @@ func decodeContent(content io.Reader, encoding string) (io.Reader, error) {
 		}
 
 		return bytes.NewReader(b), nil
-	case "7bit", "8bit":
+	case "", "7bit", "8bit":
 		dd, err := ioutil.ReadAll(content)
 		if err != nil {
 			return nil, err
 		}
 
 		return bytes.NewReader(dd), nil
-	case "":
-		return content, nil
 	default:
 		return nil, fmt.Errorf("unknown encoding: %s", encoding)
 	}


### PR DESCRIPTION
This PR fixes the case when attachment Content-Encoding-Type is quoted-printable (comes back empty from multipart.NextPart) and the attachment content returned was part of a pointer, which was being replaced on the next iteration.